### PR TITLE
Add TinyCAF team as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # self-protection
-CODEOWNERS @efellowsbg/tinycaf
+CODEOWNERS @efellowsbg/TinyCAF
 
 # pipelines
-.github @efellowsbg/tinycaf
-.vscode @efellowsbg/tinycaf
+.github @efellowsbg/TinyCAF
+.vscode @efellowsbg/TinyCAF
 
 # source code
-src @efellowsbg/tinycaf
+src @efellowsbg/TinyCAF

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # self-protection
-CODEOWNERS @efellowsbg/TinyCAF
+CODEOWNERS @efellowsbg/tinycaf
 
 # pipelines
-.github @efellowsbg/TinyCAF
-.vscode @efellowsbg/TinyCAF
+.github @efellowsbg/tinycaf
+.vscode @efellowsbg/tinycaf
 
 # source code
-src @efellowsbg/TinyCAF
+src @efellowsbg/tinycaf

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # self-protection
-CODEOWNERS @mitiko
+CODEOWNERS @efellowsbg/TinyCAF
 
 # pipelines
-.github @mitiko
-.vscode @mitiko
+.github @efellowsbg/TinyCAF
+.vscode @efellowsbg/TinyCAF
 
 # source code
-src @mitiko
+src @efellowsbg/TinyCAF


### PR DESCRIPTION
This pull request updates the .github/CODEOWNERS file to include the @efellowsbg/TinyCAF team as a code owner.
By adding TinyCAF alongside the existing @mitiko owner, any pull requests affecting the specified files or directories will automatically request reviews from both owners.

Changes:

Added @efellowsbg/TinyCAF to:

CODEOWNERS root file entry

.github directory

.vscode directory

src directory

Impact:
Ensures that the TinyCAF team is notified and can review changes relevant to pipelines, configurations, and source code, improving collaboration and oversight.