### PR TITLE
[EDO-510] Update modules relevant to a project migration

### DIFF
--- a/src/_outputs.tf
+++ b/src/_outputs.tf
@@ -153,3 +153,7 @@ output "azuread_applications" {
 output "azuread_service_principals" {
   value = module.azuread_service_principals
 }
+
+output "route_tables" {
+  value = module.route_tables
+}

--- a/src/_outputs.tf
+++ b/src/_outputs.tf
@@ -157,3 +157,7 @@ output "azuread_service_principals" {
 output "route_tables" {
   value = module.route_tables
 }
+
+output "waf_policies" {
+  value = module.waf_policies
+}

--- a/src/modules/_networking/private_endpoint/_locals.tf
+++ b/src/modules/_networking/private_endpoint/_locals.tf
@@ -18,7 +18,7 @@ locals {
   private_connection_resource_id = try(
     var.resources[
       try(var.settings.lz_key, var.client_config.landingzone_key)
-    ][local.current_resource_ref].id,
+    ][local.current_module][local.current_resource_ref].id,
     var.settings.resource_ref
   )
 

--- a/src/modules/_networking/private_endpoint/_locals.tf
+++ b/src/modules/_networking/private_endpoint/_locals.tf
@@ -19,7 +19,7 @@ locals {
   private_connection_resource_id = try(
     var.resources[
       try(var.settings.lz_key, var.client_config.landingzone_key)
-    ][local.current_resource_ref].id,
+    ][local.current_module][local.current_resource_ref].id,
     var.settings.resource_ref
   )
 

--- a/src/modules/_networking/private_endpoint/_locals.tf
+++ b/src/modules/_networking/private_endpoint/_locals.tf
@@ -2,9 +2,9 @@ locals {
   resource_group = var.resources[
     try(var.settings.lz_key, var.client_config.landingzone_key)
   ].resource_groups[var.settings.resource_group_ref]
-  resource_group_name = local.resource_group.name
-  location            = local.resource_group.location
 
+  resource_group_name  = local.resource_group.name
+  location             = local.resource_group.location
   current_module       = try(var.settings.private_service_connection.resource_type, null)
   current_resource_ref = try(var.settings.private_service_connection.resource_ref, null)
 
@@ -15,15 +15,12 @@ locals {
     var.settings.subnet_ref
   )
 
-
   private_connection_resource_id = try(
     var.resources[
       try(var.settings.lz_key, var.client_config.landingzone_key)
-    ][local.current_module][local.current_resource_ref].id,
+    ][local.current_resource_ref].id,
     var.settings.resource_ref
   )
-
-
 
   private_dns_zone_ids = try([
     for dns_zone_ref in try(var.settings.private_dns_zone_group.private_dns_zone_refs, []) :

--- a/src/modules/_networking/virtual_network_gateway/_outputs.tf
+++ b/src/modules/_networking/virtual_network_gateway/_outputs.tf
@@ -1,3 +1,9 @@
 output "id" {
   value = azurerm_virtual_network_gateway.main.id
 }
+
+output "nat_rule_ids" {
+  value = {
+    for k, v in azurerm_virtual_network_gateway_nat_rule.main : k => v.id
+  }
+}

--- a/src/modules/_networking/virtual_network_gateway/_outputs.tf
+++ b/src/modules/_networking/virtual_network_gateway/_outputs.tf
@@ -4,6 +4,9 @@ output "id" {
 
 output "nat_rule_ids" {
   value = {
-    for k, v in azurerm_virtual_network_gateway_nat_rule.main : k => v.id
+    for k, v in azurerm_virtual_network_gateway_nat_rule.main : k => {
+      id   = v.id
+      name = v.name
+    }
   }
 }

--- a/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
+++ b/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
@@ -1,0 +1,27 @@
+resource "azurerm_virtual_network_gateway_nat_rule" "main" {
+  for_each                   = try(var.settings.vng_nat_rules, {})
+  name                       = each.value.name
+  resource_group_name        = local.resource_group_name
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.main.id
+  mode                       = try(each.value.mode, "EgressSnat")
+  type                       = try(each.value.type, "Static")
+  ip_configuration_id        = try(each.value.ip_configuration_id, "")
+
+  dynamic "external_mapping" {
+    for_each = try(each.value.external_mappings, [])
+
+    content {
+      address_space = external_mapping.value.address_space
+      port_range    = try(external_mapping.value.port_range, null)
+    }
+  }
+
+  dynamic "internal_mapping" {
+    for_each = try(each.value.internal_mappings, [])
+
+    content {
+      address_space = internal_mapping.value.address_space
+      port_range    = try(internal_mapping.value.port_range, null)
+    }
+  }
+}

--- a/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
+++ b/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
@@ -5,7 +5,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "main" {
   virtual_network_gateway_id = azurerm_virtual_network_gateway.main.id
   mode                       = try(each.value.mode, "EgressSnat")
   type                       = try(each.value.type, "Static")
-  ip_configuration_id        = try(each.value.ip_configuration_id, "")
+  ip_configuration_id        = try(each.value.ip_configuration_id, null)
 
   dynamic "external_mapping" {
     for_each = try(each.value.external_mappings, {})

--- a/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
+++ b/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "main" {
   ip_configuration_id        = try(each.value.ip_configuration_id, "")
 
   dynamic "external_mapping" {
-    for_each = each.value.external_mapping
+    for_each = try(each.value.external_mappings, {})
 
     content {
       address_space = external_mapping.value.address_space
@@ -17,7 +17,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "main" {
   }
 
   dynamic "internal_mapping" {
-    for_each = each.value.internal_mapping
+    for_each = try(each.value.internal_mappings, {})
 
     content {
       address_space = internal_mapping.value.address_space

--- a/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
+++ b/src/modules/_networking/virtual_network_gateway/vng_nat_rules.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "main" {
   ip_configuration_id        = try(each.value.ip_configuration_id, "")
 
   dynamic "external_mapping" {
-    for_each = try(each.value.external_mappings, [])
+    for_each = each.value.external_mapping
 
     content {
       address_space = external_mapping.value.address_space
@@ -17,7 +17,7 @@ resource "azurerm_virtual_network_gateway_nat_rule" "main" {
   }
 
   dynamic "internal_mapping" {
-    for_each = try(each.value.internal_mappings, [])
+    for_each = each.value.internal_mapping
 
     content {
       address_space = internal_mapping.value.address_space

--- a/src/modules/_networking/virtual_network_gateway_connections/_data.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/_data.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault_secret" "main" {
-  count = var.settings.shared_key_secret != null ? 1 : 0
+  count = try(var.settings.shared_key_secret, null) != null ? 1 : 0
   name  = try(element(split("/", var.settings.shared_key_secret), 1), null)
 
   key_vault_id = try(

--- a/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
@@ -12,6 +12,13 @@ locals {
     null
   )
 
+  egress_nat_rule_ids = try([
+    for nat_rule_ref in try(var.settings.egress_nat_rule_refs, []) :
+    var.resources[
+      try(var.settings.lz_key, var.client_config.landingzone_key)
+    ].virtual_network_gateways[var.settings.virtual_network_gateway_re].azurerm_virtual_network_gateway_nat_rules[nat_rule_ref]
+  ], [])
+
   local_network_gateway_id = try(
     var.resources[
       try(var.settings.local_network_gateway_lz_key, var.client_config.landingzone_key)

--- a/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
@@ -22,7 +22,7 @@ locals {
   local_network_gateway_id = try(
     var.resources[
       try(var.settings.local_network_gateway_lz_key, var.client_config.landingzone_key)
-    ].local_network_gateways[var.settings.local_network_gateway_ref].id,
+    ].local_network_gateways[var.settings.local_network_gateway_ref],
     null
   )
 

--- a/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
@@ -22,7 +22,7 @@ locals {
   local_network_gateway_id = try(
     var.resources[
       try(var.settings.local_network_gateway_lz_key, var.client_config.landingzone_key)
-    ].local_network_gateways[var.settings.local_network_gateway_ref],
+    ].local_network_gateways[var.settings.local_network_gateway_ref].id,
     null
   )
 

--- a/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
@@ -16,7 +16,7 @@ locals {
     for nat_rule_ref in try(var.settings.egress_nat_rule_refs, []) :
     var.resources[
       try(var.settings.lz_key, var.client_config.landingzone_key)
-    ].virtual_network_gateways[var.settings.virtual_network_gateway_re].azurerm_virtual_network_gateway_nat_rules[nat_rule_ref]
+    ].virtual_network_gateways[var.settings.virtual_network_gateway_ref].azurerm_virtual_network_gateway_nat_rules[nat_rule_ref].id
   ], [])
 
   local_network_gateway_id = try(

--- a/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/_locals.tf
@@ -16,7 +16,7 @@ locals {
     for nat_rule_ref in try(var.settings.egress_nat_rule_refs, []) :
     var.resources[
       try(var.settings.lz_key, var.client_config.landingzone_key)
-    ].virtual_network_gateways[var.settings.virtual_network_gateway_ref].azurerm_virtual_network_gateway_nat_rules[nat_rule_ref].id
+    ].virtual_network_gateways[var.settings.virtual_network_gateway_ref].nat_rule_ids[nat_rule_ref].id
   ], [])
 
   local_network_gateway_id = try(

--- a/src/modules/_networking/virtual_network_gateway_connections/main.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/main.tf
@@ -7,8 +7,8 @@ resource "azurerm_virtual_network_gateway_connection" "main" {
 
   virtual_network_gateway_id         = local.virtual_network_gateway_id
   local_network_gateway_id           = local.local_network_gateway_id
-  ingress_nat_rule_ids               = try(var.settings.ingress_nat_rule_ids, [])
   egress_nat_rule_ids                = local.egress_nat_rule_ids
+  ingress_nat_rule_ids               = try(var.settings.ingress_nat_rule_ids, [])
   enable_bgp                         = try(var.settings.enable_bgp, false)
   type                               = try(var.settings.type, "IPsec")
   routing_weight                     = try(var.settings.routing_weight, null)

--- a/src/modules/_networking/virtual_network_gateway_connections/main.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/main.tf
@@ -8,11 +8,14 @@ resource "azurerm_virtual_network_gateway_connection" "main" {
   virtual_network_gateway_id         = local.virtual_network_gateway_id
   local_network_gateway_id           = local.local_network_gateway_id
   ingress_nat_rule_ids               = try(var.settings.ingress_nat_rule_ids, [])
+  egress_nat_rule_ids                = try(var.settings.egress_nat_rule_ids, [])
   enable_bgp                         = try(var.settings.enable_bgp, false)
   type                               = try(var.settings.type, "IPsec")
   routing_weight                     = try(var.settings.routing_weight, null)
   connection_protocol                = try(var.settings.connection_protocol, "IKEv2")
   use_policy_based_traffic_selectors = try(var.settings.use_policy_based_traffic_selectors, true)
+  express_route_gateway_bypass       = try(var.settings.express_route_gateway_bypass, false)
+  local_azure_ip_address_enabled     = try(var.settings.local_azure_ip_address_enabled, false)
 
   shared_key = try(var.settings.shared_key, null) != null ? var.settings.shared_key : (
     try(var.settings.shared_key_secret, null) != null && length(data.azurerm_key_vault_secret.main) > 0

--- a/src/modules/_networking/virtual_network_gateway_connections/main.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network_gateway_connection" "main" {
   virtual_network_gateway_id         = local.virtual_network_gateway_id
   local_network_gateway_id           = local.local_network_gateway_id
   ingress_nat_rule_ids               = try(var.settings.ingress_nat_rule_ids, [])
-  egress_nat_rule_ids                = try(var.settings.egress_nat_rule_ids, [])
+  egress_nat_rule_ids                = local.egress_nat_rule_ids
   enable_bgp                         = try(var.settings.enable_bgp, false)
   type                               = try(var.settings.type, "IPsec")
   routing_weight                     = try(var.settings.routing_weight, null)

--- a/src/modules/_networking/vnet_peering/main.tf
+++ b/src/modules/_networking/vnet_peering/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_virtual_network_peering" "left_to_right" {
   resource_group_name       = local.vnet_left.resource_group_name
   virtual_network_name      = local.vnet_left.name
   remote_virtual_network_id = local.vnet_right.id
+  use_remote_gateways       = try(var.settings.use_remote_gateways, true)
 }
 
 resource "azurerm_virtual_network_peering" "right_to_left" {
@@ -14,6 +15,7 @@ resource "azurerm_virtual_network_peering" "right_to_left" {
   resource_group_name       = local.vnet_right.resource_group_name
   virtual_network_name      = local.vnet_right.name
   remote_virtual_network_id = local.vnet_left.id
+  allow_gateway_transit     = try(var.settings.allow_gateway_transit, true)
 }
 
 resource "azurerm_virtual_network_peering" "target" {

--- a/src/modules/_security/web_application_firewall_policy/_outputs.tf
+++ b/src/modules/_security/web_application_firewall_policy/_outputs.tf
@@ -1,13 +1,3 @@
 output "id" {
   value = azurerm_web_application_firewall_policy.main.id
 }
-
-output "waf_policies" {
-  value = {
-    for k, v in azurerm_web_application_firewall_policy.main :
-    k => {
-      id   = v.id
-      name = v.name
-    }
-  }
-}

--- a/src/modules/_security/web_application_firewall_policy/_outputs.tf
+++ b/src/modules/_security/web_application_firewall_policy/_outputs.tf
@@ -1,3 +1,13 @@
 output "id" {
   value = azurerm_web_application_firewall_policy.main.id
 }
+
+output "waf_policies" {
+  value = {
+    for k, v in azurerm_web_application_firewall_policy.main :
+    k => {
+      id   = v.id
+      name = v.name
+    }
+  }
+}

--- a/src/modules/_security/web_application_firewall_policy/_outputs.tf
+++ b/src/modules/_security/web_application_firewall_policy/_outputs.tf
@@ -1,10 +1,3 @@
 output "id" {
   value = azurerm_web_application_firewall_policy.main.id
 }
-
-output "waf_policies" {
-  value = {
-    for k, v in azurerm_web_application_firewall_policy.main :
-    k => { id = v.id, name = v.name }
-  }
-}

--- a/src/modules/_security/web_application_firewall_policy/_outputs.tf
+++ b/src/modules/_security/web_application_firewall_policy/_outputs.tf
@@ -1,3 +1,10 @@
 output "id" {
   value = azurerm_web_application_firewall_policy.main.id
 }
+
+output "waf_policies" {
+  value = {
+    for k, v in azurerm_web_application_firewall_policy.main :
+    k => { id = v.id, name = v.name }
+  }
+}

--- a/src/modules/compute/kubernetes/kubernetes_cluster/main.tf
+++ b/src/modules/compute/kubernetes/kubernetes_cluster/main.tf
@@ -143,8 +143,8 @@ resource "azurerm_kubernetes_cluster" "main" {
   dynamic "windows_profile" {
     for_each = can(var.settings.windows_profile) ? [1] : []
     content {
-      admin_username = try(var.settings.windows_profile, null)
-      admin_password = try(var.settings.windows_profile, null)
+      admin_username = try(var.settings.windows_profile.admin_username, null)
+      admin_password = try(var.settings.windows_profile.admin_password, null)
     }
   }
 }

--- a/src/modules/compute/kubernetes/kubernetes_cluster/main.tf
+++ b/src/modules/compute/kubernetes/kubernetes_cluster/main.tf
@@ -15,6 +15,11 @@ resource "azurerm_kubernetes_cluster" "main" {
   oidc_issuer_enabled                 = try(var.settings.oidc_issuer_enabled, false)
   workload_identity_enabled           = try(var.settings.oidc_issuer_enabled ? var.settings.workload_identity_enabled : false, false)
   open_service_mesh_enabled           = try(var.settings.open_service_mesh_enabled, null)
+  cost_analysis_enabled               = try(var.settings.cost_analysis_enabled, false)
+  image_cleaner_enabled               = try(var.settings.image_cleaner_enabled, false)
+  node_os_upgrade_channel             = try(var.settings.node_os_upgrade_channel, null)
+  image_cleaner_interval_hours        = try(var.settings.image_cleaner_interval_hours, null)
+  local_account_disabled              = try(var.settings.local_account_disabled, null)
 
   default_node_pool {
     vnet_subnet_id              = local.vnet_subnet_id
@@ -33,6 +38,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     pod_subnet_id               = try(var.settings.default_node_pool.pod_subnet_id, null)
     temporary_name_for_rotation = try(var.settings.default_node_pool.temporary_name_for_rotation, null)
     host_encryption_enabled     = try(var.settings.default_node_pool.host_encryption_enabled, false)
+    fips_enabled                = try(var.settings.default_node_pool.fips_enabled, false)
 
     dynamic "upgrade_settings" {
       for_each = try(var.settings.default_node_pool.upgrade_settings[*], {})
@@ -49,7 +55,6 @@ resource "azurerm_kubernetes_cluster" "main" {
     network_plugin      = local.effective_network_profile.network_plugin
     network_mode        = local.effective_network_profile.network_mode
     network_policy      = local.effective_network_profile.network_policy
-    load_balancer_sku   = local.effective_network_profile.load_balancer_sku
     network_data_plane  = local.validated_network_data_plane
     network_plugin_mode = local.effective_network_profile.network_plugin_mode
     outbound_type       = local.effective_network_profile.outbound_type
@@ -57,10 +62,17 @@ resource "azurerm_kubernetes_cluster" "main" {
     service_cidr        = local.effective_network_profile.service_cidr
     service_cidrs       = local.effective_network_profile.service_cidrs
     pod_cidr            = local.validated_pod_cidr
+    ip_versions         = try(var.settings.ip_versions, ["IPv4"])
+    load_balancer_sku   = local.effective_network_profile.load_balancer_sku
+
+    dynamic "load_balancer_profile" {
+      for_each = can(var.settings.network_profile.load_balancer_profile) ? [1] : []
+      content {
+        backend_pool_type = try(load_balancer_profile.value.backend_pool_type, "NodeIPConfigurations")
+      }
+    }
   }
-  node_os_upgrade_channel      = try(var.settings.node_os_upgrade_channel, null)
-  image_cleaner_interval_hours = try(var.settings.image_cleaner_interval_hours, null)
-  local_account_disabled       = try(var.settings.local_account_disabled, null)
+
   identity {
     type         = try(var.settings.identity.type, "SystemAssigned")
     identity_ids = try(var.settings.identity.type == "UserAssigned" ? [local.managed_identity.id] : null, null)
@@ -109,6 +121,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       user_assigned_identity_id = try(kubelet_identity.value.type == "UserAssigned" ? local.kubelet_identity.id : null, null)
     }
   }
+
   dynamic "upgrade_override" {
     for_each = can(var.settings.upgrade_override) ? [1] : []
     content {
@@ -116,6 +129,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       effective_until       = try(var.settings.upgrade_override.effective_until, null)
     }
   }
+
   dynamic "linux_profile" {
     for_each = try(var.settings.linux_profile, null) == null ? [] : [1]
     content {
@@ -126,5 +140,11 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
-
+  dynamic "windows_profile" {
+    for_each = can(var.settings.windows_profile) ? [1] : []
+    content {
+      admin_username = try(var.settings.windows_profile, null)
+      admin_password = try(var.settings.windows_profile, null)
+    }
+  }
 }

--- a/src/modules/mssql_managed_instance/_locals.tf
+++ b/src/modules/mssql_managed_instance/_locals.tf
@@ -29,6 +29,15 @@ locals {
     null
   )
 
+  administrator_login = try(
+    (
+      length(trimspace(var.settings.key_vault_ref)) > 0
+      ? try(var.settings.administrator_login, "mssqlmiadmin")
+      : null
+    ),
+    null
+  )
+
   administrator_login_password = try(
     (
       try(length(trimspace(var.settings.key_vault_ref)) > 0, false)

--- a/src/modules/mssql_managed_instance/_locals.tf
+++ b/src/modules/mssql_managed_instance/_locals.tf
@@ -29,15 +29,6 @@ locals {
     null
   )
 
-  administrator_login = try(
-    (
-      length(trimspace(var.settings.key_vault_ref)) > 0
-      ? try(var.settings.administrator_login, "mssqlmiadmin")
-      : null
-    ),
-    null
-  )
-
   administrator_login_password = try(
     (
       try(length(trimspace(var.settings.key_vault_ref)) > 0, false)

--- a/src/modules/mssql_managed_instance/_locals.tf
+++ b/src/modules/mssql_managed_instance/_locals.tf
@@ -19,12 +19,22 @@ locals {
       try(var.settings.identity.managed_identity_lz_key, var.client_config.landingzone_key)
     ].managed_identities[id_ref].id
   ]
+
   key_vault_id = try(
     var.resources[
       try(var.settings.key_vault_lz_key, var.client_config.landingzone_key)
       ].keyvaults[
       var.settings.key_vault_ref
     ].id,
+    null
+  )
+
+  administrator_login_password = try(
+    (
+      try(length(trimspace(var.settings.key_vault_ref)) > 0, false)
+      ? random_password.admin[0].result
+      : try(var.settings.administrator_login_password, random_password.admin[0].result)
+    ),
     null
   )
 

--- a/src/modules/mssql_managed_instance/_locals.tf
+++ b/src/modules/mssql_managed_instance/_locals.tf
@@ -5,6 +5,15 @@ locals {
   resource_group_name = local.resource_group.name
   location            = local.resource_group.location
 
+  dns_zone_group = try(
+    var.resources[
+      try(var.settings.private_endpoint.dns_lz_key, var.client_config.landingzone_key)
+    ].private_dns_zones[var.settings.private_endpoint.private_dns_zone_group_ref],
+    null
+  )
+  dns_zone_group_name  = try(local.dns_zone_group.name, null)
+  private_dns_zone_ids = try([local.dns_zone_group.id], null)
+
   subnet_id = var.resources[
     try(var.settings.subnet_lz_key, var.client_config.landingzone_key)
     ].virtual_networks[

--- a/src/modules/mssql_managed_instance/main.tf
+++ b/src/modules/mssql_managed_instance/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_mssql_managed_instance" "main" {
   storage_size_in_gb = try(var.settings.storage_size_in_gb, "32")
   vcores             = try(var.settings.vcores, "4")
 
-  administrator_login            = local.administrator_login
+  administrator_login            = try(var.settings.administrator_login, "mssqlmiadmin")
   administrator_login_password   = local.administrator_login_password
   collation                      = try(var.settings.collation, null)
   dns_zone_partner_id            = try(var.settings.dns_zone_partner_id, null)

--- a/src/modules/mssql_managed_instance/main.tf
+++ b/src/modules/mssql_managed_instance/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_mssql_managed_instance" "main" {
   storage_size_in_gb = try(var.settings.storage_size_in_gb, "32")
   vcores             = try(var.settings.vcores, "4")
 
-  administrator_login            = var.settings.key_vault_ref != null ? try(var.settings.administrator_login, "mssqlmiadmin") : null
+  administrator_login            = local.administrator_login
   administrator_login_password   = local.administrator_login_password
   collation                      = try(var.settings.collation, null)
   dns_zone_partner_id            = try(var.settings.dns_zone_partner_id, null)

--- a/src/modules/mssql_managed_instance/main.tf
+++ b/src/modules/mssql_managed_instance/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_mssql_managed_instance" "main" {
   vcores             = try(var.settings.vcores, "4")
 
   administrator_login            = var.settings.key_vault_ref != null ? try(var.settings.administrator_login, "mssqlmiadmin") : null
-  administrator_login_password   = var.settings.key_vault_ref != null ? random_password.admin[0].result : null
+  administrator_login_password   = local.administrator_login_password
   collation                      = try(var.settings.collation, null)
   dns_zone_partner_id            = try(var.settings.dns_zone_partner_id, null)
   maintenance_configuration_name = try(var.settings.maintenance_configuration_name, null)

--- a/src/modules/mssql_managed_instance/private_endpoint.tf
+++ b/src/modules/mssql_managed_instance/private_endpoint.tf
@@ -4,18 +4,28 @@ resource "azurerm_private_endpoint" "main" {
   name                = try(var.settings.private_endpoint.name, "pe-${var.settings.name}")
   resource_group_name = local.resource_group_name
   location            = local.location
-  subnet_id           = local.subnet_id
-  tags                = try(var.settings.private_endpoint.tags, local.tags)
+  subnet_id = var.resources[
+    try(var.settings.private_endpoint.subnet_lz_key, var.client_config.landingzone_key)
+    ].virtual_networks[
+    split("/", var.settings.private_endpoint.subnet_ref)[0]
+    ].subnets[
+    split("/", var.settings.private_endpoint.subnet_ref)[1]
+  ].id
+  tags = try(var.settings.private_endpoint.tags, local.tags)
 
   private_service_connection {
     name                           = try(var.settings.private_endpoint.private_service_connection.name, "psc-${var.settings.name}")
-    private_connection_resource_id = azurerm_container_registry.main.id
+    private_connection_resource_id = azurerm_mssql_managed_instance.main.id
     is_manual_connection           = try(var.settings.private_endpoint.private_service_connection.is_manual_connection, false)
     subresource_names              = ["managedInstance"]
   }
 
-  private_dns_zone_group {
-    name                 = try(var.settings.private_endpoint.private_dns_zone_group_name, local.dns_zone_group_name)
-    private_dns_zone_ids = local.private_dns_zone_ids
+  dynamic "private_dns_zone_group" {
+    for_each = can(var.settings.private_endpoint.private_dns_zone_group) ? [1] : []
+
+    content {
+      name                 = try(var.settings.private_endpoint.private_dns_zone_group_name, local.dns_zone_group_name)
+      private_dns_zone_ids = local.private_dns_zone_ids
+    }
   }
 }

--- a/src/modules/mssql_managed_instance/private_endpoint.tf
+++ b/src/modules/mssql_managed_instance/private_endpoint.tf
@@ -1,0 +1,21 @@
+resource "azurerm_private_endpoint" "main" {
+  count = try(var.settings.private_endpoint, null) == null ? 0 : 1
+
+  name                = try(var.settings.private_endpoint.name, "pe-${var.settings.name}")
+  resource_group_name = local.resource_group_name
+  location            = local.location
+  subnet_id           = local.subnet_id
+  tags                = try(var.settings.private_endpoint.tags, local.tags)
+
+  private_service_connection {
+    name                           = try(var.settings.private_endpoint.private_service_connection.name, "psc-${var.settings.name}")
+    private_connection_resource_id = azurerm_container_registry.main.id
+    is_manual_connection           = try(var.settings.private_endpoint.private_service_connection.is_manual_connection, false)
+    subresource_names              = ["managedInstance"]
+  }
+
+  private_dns_zone_group {
+    name                 = try(var.settings.private_endpoint.private_dns_zone_group_name, local.dns_zone_group_name)
+    private_dns_zone_ids = local.private_dns_zone_ids
+  }
+}

--- a/src/mssql_managed_instances.tf
+++ b/src/mssql_managed_instances.tf
@@ -15,6 +15,7 @@ module "mssql_managed_instances" {
         managed_identities      = module.managed_identities
         network_security_groups = module.network_security_groups
         keyvaults               = module.keyvaults
+        private_dns_zones       = module.private_dns_zones
       }
     },
     {

--- a/src/networking.tf
+++ b/src/networking.tf
@@ -238,10 +238,13 @@ module "private_endpoints" {
   resources = merge(
     {
       (var.landingzone.key) = {
-        resource_groups   = module.resource_groups
-        virtual_networks  = module.virtual_networks
-        private_dns_zones = module.private_dns_zones
-        storage_accounts  = module.storage_accounts
+        resource_groups         = module.resource_groups
+        virtual_networks        = module.virtual_networks
+        private_dns_zones       = module.private_dns_zones
+        storage_accounts        = module.storage_accounts
+        container_registries    = module.container_registries
+        keyvaults               = module.keyvaults
+        mssql_managed_instances = module.mssql_managed_instances
       }
     },
     {


### PR DESCRIPTION
[EDO-510] Module Updates

private_endpoint – Corrects the private_connection_resource_id reference.

virtual_network_gateways – Adds nat_rules instantiation option and outputs module instance IDs.

virtual_network_gateway_connections – Adds missing optional parameters and improves error handling.

vnet_peerings – Adds missing optional parameters.

kubernetes_cluster – Adds missing optional parameters.

mssql_managed_instances – Enables creation of private_endpoint and adds logic for the administrator_login_password parameter.

CAF Module Changes

Adds waf_policies to outputs.

Introduces dependencies for networking modules.

[EDO-510]: https://efellows.atlassian.net/browse/EDO-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ