### PR TITLE
[TC-64] Add support in keyvault access policies

### DIFF
--- a/examples/keyvaults.tfvars
+++ b/examples/keyvaults.tfvars
@@ -2,6 +2,15 @@ keyvaults = {
   kv_test = {
     name               = "kv-test-dv-ne-01"
     resource_group_ref = "rg_test"
+    access_policies = {
+      access_policy_01 = {
+        secret_permissions      = ["Get", "List", "Set", "Delete", "Recover", "Backup", "Restore", "Purge"]
+        key_permissions         = ["Get", "List", "Update", "Create", "Import", "Decrypt", "Delete", "Encrypt", "Recover", "Backup", "Restore", "Purge", "Sign", "UnwrapKey", "Verify", "WrapKey"]
+        certificate_permissions = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Recover", "Restore", "SetIssuers", "Update", "Purge"]
+        object_ids              = ["00000000-0000-0000-0000-000000000000"]
+        user_principal_names    = ["user.one@test.com", "user.two@test.com"]
+      }
+    }
     network_rules = {
       default_action = "Deny"
       allowed_ips    = ["10.10.10.10", "20.20.20.20"]

--- a/src/_provider.tf
+++ b/src/_provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azapi = {
       source  = "Azure/azapi"
-      version = "2.5.0" // version
+      version = "2.5.0"
     }
   }
 }
@@ -18,8 +18,4 @@ provider "azurerm" {
   client_id       = var.client_id
   tenant_id       = var.tenant_id
   subscription_id = var.subscription_id
-}
-
-provider "azapi" {
-  # Configuration options
 }

--- a/src/modules/keyvault/keyvault_access_policy/_locals.tf
+++ b/src/modules/keyvault/keyvault_access_policy/_locals.tf
@@ -62,6 +62,16 @@ locals {
         }
       ],
       [
+        for upn, u in data.azuread_user.kv_policy_users : {
+          key                     = "${var.policy_name}_aad_user_${replace(replace(upn, "@", "_"), ".", "_")}"
+          object_id               = u.object_id
+          key_permissions         = local.key_permissions
+          secret_permissions      = local.secret_permissions
+          certificate_permissions = local.certificate_permissions
+          storage_permissions     = local.storage_permissions
+        }
+      ],
+      [
         for include in [true] : {
           key                     = "${var.policy_name}_logged_in_user"
           object_id               = var.global_settings.object_id

--- a/src/modules/keyvault/keyvault_access_policy/main.tf
+++ b/src/modules/keyvault/keyvault_access_policy/main.tf
@@ -13,6 +13,6 @@ module "access_policy" {
 
 
 data "azuread_user" "kv_policy_users" {
-  for_each = toset(try(var.access_policies.user_principal_name_refs, []))
+  for_each            = toset(try(var.access_policies.user_principal_names, []))
   user_principal_name = each.key
 }

--- a/src/modules/keyvault/keyvault_access_policy/main.tf
+++ b/src/modules/keyvault/keyvault_access_policy/main.tf
@@ -10,3 +10,9 @@ module "access_policy" {
   certificate_permissions = each.value.certificate_permissions
   storage_permissions     = each.value.storage_permissions
 }
+
+
+data "azuread_user" "kv_policy_users" {
+  for_each = toset(try(var.access_policies.user_principal_name_refs, []))
+  user_principal_name = each.key
+}


### PR DESCRIPTION
This PR introduces two main changes to the CAF module:

### 1. Removed redundant azapi provider blocks
- Removed empty `provider "azapi" {}` blocks from `_provider.tf` as they are deprecated in Terraform 1.3+.
- Updated module to rely only on the `required_providers` declaration and provider inheritance from the root configuration.
- Eliminates warnings seen during `terraform init`.

### 2. Extended Key Vault access policy support for Azure AD users by UPN
- Added `var.access_policies.user_principal_names` support to allow passing a list of user principal names (UPNs).
- Introduced `data "azuread_user"` lookup to resolve UPNs to object IDs.
- Updated `locals.normalized_access_policies` to include these users alongside managed identities, object IDs, and Azure AD applications.
- Ensures consistent permissions application (`key_permissions`, `secret_permissions`, etc.) for UPN-based users.
