### PR TITLE
[TC-65] Add support for managed identity on Linux VM

### DIFF
--- a/examples/virtual_machines.tfvars
+++ b/examples/virtual_machines.tfvars
@@ -12,6 +12,10 @@ virtual_machines = {
       storage_account_type = "Standard_LRS"
     }
 
+    identity = {
+      type = "SystemAssigned"
+    }
+
     source_image_reference = {
       publisher = "MicrosoftWindowsServer"
       offer     = "WindowsServer"
@@ -45,6 +49,10 @@ virtual_machines = {
     size               = "Standard_F2"
     admin_username     = "adminuser"
     keyvault_ref       = "kv-test"
+    identity = {
+      type             = "SystemAssigned,UserAssigned"
+      identity_ids_ref = ["mi_test"]
+    }
 
     network_interfaces = {
       nic_3 = {

--- a/examples/virtual_machines.tfvars
+++ b/examples/virtual_machines.tfvars
@@ -50,7 +50,7 @@ virtual_machines = {
     admin_username     = "adminuser"
     keyvault_ref       = "kv-test"
     identity = {
-      type             = "SystemAssigned,UserAssigned"
+      type             = "SystemAssigned, UserAssigned"
       identity_ids_ref = ["mi_test"]
     }
 

--- a/src/modules/virtual_machines/linux_virtual_machine/_locals.tf
+++ b/src/modules/virtual_machines/linux_virtual_machine/_locals.tf
@@ -6,7 +6,12 @@ locals {
   location            = local.resource_group.location
 
   network_interface_ids = module.network_interface.ids
-
+  identity_ids = [
+    for id_ref in try(var.settings.identity.identity_ids_ref, []) :
+    var.resources[
+      try(var.settings.identity.managed_identity_lz_key, var.client_config.landingzone_key)
+    ].managed_identities[id_ref].id
+  ]
   key_vault_id = try(var.resources[
     try(var.settings.keyvault_lz_key, var.client_config.landingzone_key)
     ].keyvaults[

--- a/src/modules/virtual_machines/linux_virtual_machine/linux_virtual_machine.tf
+++ b/src/modules/virtual_machines/linux_virtual_machine/linux_virtual_machine.tf
@@ -10,7 +10,14 @@ resource "azurerm_linux_virtual_machine" "main" {
   disable_password_authentication = try(var.settings.disable_password_authentication, null)
   availability_set_id             = try(one(azurerm_availability_set.main[*].id), null)
 
+  dynamic "identity" {
+    for_each = can(var.settings.identity) ? [1] : []
 
+    content {
+      type         = var.settings.identity.type
+      identity_ids = try(local.identity_ids, null)
+    }
+  }
   tags = local.tags
 
   dynamic "admin_ssh_key" {


### PR DESCRIPTION
This PR introduces support for managed identities on Linux Virtual Machines within the Terraform CAF azurerm module.
The change fulfills requirement TC-65 and extends the module’s functionality to enable secure authentication via both system-assigned and user-assigned identities.

Details

Added support for configuring:

System-assigned identity

User-assigned identity

Combined configuration (both system- and user-assigned)

An example has been added to demonstrate correct usage.

Important: The type parameter is case sensitive.

Example: SystemAssigned, UserAssigned, and SystemAssigned, UserAssigned must be written exactly as shown.

In future versions, functionality may be added to allow case-insensitive values.

Example

identity {
  type         = "SystemAssigned, UserAssigned"
  identity_ids_ref = [test]
}