### PR TITLE
[TC-67] DNS Zone Module: Correct lz_key Handling in VNet Link Loops

### DIFF
--- a/examples/private_dns_zones.tfvars
+++ b/examples/private_dns_zones.tfvars
@@ -18,7 +18,8 @@ private_dns_zones = {
         vnet_ref = "vnet_test2"
       }
       link2 = {
-        vnet_ref = "sandbox/vnet_test2"
+        lz_key = "sandbox"
+        vnet_ref = "vnet_test2"
         name     = "custom_name2"
       }
     }

--- a/examples/private_dns_zones.tfvars
+++ b/examples/private_dns_zones.tfvars
@@ -18,7 +18,7 @@ private_dns_zones = {
         vnet_ref = "vnet_test2"
       }
       link2 = {
-        lz_key = "sandbox"
+        lz_key   = "sandbox"
         vnet_ref = "vnet_test2"
         name     = "custom_name2"
       }

--- a/src/modules/_networking/private_dns_zone/_locals.tf
+++ b/src/modules/_networking/private_dns_zone/_locals.tf
@@ -14,7 +14,7 @@ locals {
         "${var.resources[
           length(split("/", link.vnet_ref)) > 1 ?
           split("/", link.vnet_ref)[0] :
-          try(var.settings.lz_key, var.client_config.landingzone_key)
+          try(link.lz_key, var.client_config.landingzone_key)
           ].virtual_networks[
           length(split("/", link.vnet_ref)) > 1 ?
           split("/", link.vnet_ref)[1] :
@@ -25,7 +25,7 @@ locals {
       id = var.resources[
         length(split("/", link.vnet_ref)) > 1 ?
         split("/", link.vnet_ref)[0] :
-        try(var.settings.lz_key, var.client_config.landingzone_key)
+        try(link.lz_key, var.client_config.landingzone_key)
         ].virtual_networks[
         length(split("/", link.vnet_ref)) > 1 ?
         split("/", link.vnet_ref)[1] :


### PR DESCRIPTION
[TC-67] DNS Zone Module: Correct lz_key Handling in VNet Link Loops
This PR addresses an issue in the DNS zone module where the lz_key reference for virtual network (VNet) links was not being handled correctly.

Problem

Previously, the lz_key was not retrieved dynamically for each VNet link within the loop. This caused incorrect or duplicated references, leading to misconfigured VNet links in the DNS zone.

Solution

Updated the logic so that the lz_key is now correctly obtained for every iteration of the VNet link loop.

Ensures that each VNet link is associated with the proper lz_key reference.

Improves consistency and prevents configuration drift or invalid link setups.

Impact

Corrects VNet link creation in DNS zones.

Reduces risk of deployment errors due to invalid references.

[TC-67]: https://efellows.atlassian.net/browse/TC-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ