### PR TITLE
Release/v1.4.1

### DIFF
--- a/examples/azuread_applications.tfvars
+++ b/examples/azuread_applications.tfvars
@@ -18,6 +18,17 @@ azuread_applications = {
       issuer      = "https://token.actions.githubusercontent.com"
       subject     = "repo:my-organization/my-repo:environment:prod"
     }
+
+    # Optional additional azuread_application_federated_identity_credential resources
+    # on the same Azure AD application.
+    create_fed_credentials_additional = {
+      pull_requests = {
+        description = "Pull request validation for my-repo"
+        audiences   = ["api://AzureADTokenExchange"]
+        issuer      = "https://token.actions.githubusercontent.com"
+        subject     = "repo:my-organization/my-repo:pull_request"
+      }
+    }
     # ===========================================================================
     # ===========================================================================
     api = {

--- a/src/azuread_applications.tf
+++ b/src/azuread_applications.tf
@@ -47,17 +47,45 @@ module "azuread_application_passwords" {
   )
 }
 
-module "ad_app_fed_idy_credentials" {
-  source = "./modules/azuread_application/ad_app_fed_idy_credential"
-  for_each = {
+locals {
+  azuread_application_federated_identity_credentials_primary = {
     for instance, cfg in var.azuread_applications :
-    instance => cfg
+    instance => {
+      application_key = instance
+      settings        = cfg
+    }
     if try(cfg.create_fed_credentials, null) != null
   }
-  settings         = each.value
+
+  azuread_application_federated_identity_credentials_additional = merge(concat(
+    [{}],
+    [
+      for instance, cfg in var.azuread_applications : {
+        for credential_key, credential in try(cfg.create_fed_credentials_additional, {}) :
+        "${instance}.${credential_key}" => {
+          application_key = instance
+          settings = merge(cfg, {
+            create_fed_credentials = credential
+          })
+        }
+      }
+    ]
+  )...)
+
+  azuread_application_federated_identity_credentials = merge(
+    local.azuread_application_federated_identity_credentials_primary,
+    local.azuread_application_federated_identity_credentials_additional
+  )
+}
+
+module "ad_app_fed_idy_credentials" {
+  source   = "./modules/azuread_application/ad_app_fed_idy_credential"
+  for_each = local.azuread_application_federated_identity_credentials
+
+  settings         = each.value.settings
   global_settings  = local.global_settings
-  application_id   = module.azuread_applications[each.key].id
-  application_name = module.azuread_applications[each.key].display_name
+  application_id   = module.azuread_applications[each.value.application_key].id
+  application_name = module.azuread_applications[each.value.application_key].display_name
 
   client_config = {
     landingzone_key = var.landingzone.key

--- a/src/modules/compute/kubernetes/_outputs.tf
+++ b/src/modules/compute/kubernetes/_outputs.tf
@@ -1,3 +1,11 @@
 output "id" {
   value = module.kubernetes_cluster.id
 }
+
+output "identity" {
+  value = module.kubernetes_cluster.identity
+}
+
+output "kubelet_identity" {
+  value = module.kubernetes_cluster.kubelet_identity
+}

--- a/src/modules/compute/kubernetes/kubernetes_cluster/_outputs.tf
+++ b/src/modules/compute/kubernetes/kubernetes_cluster/_outputs.tf
@@ -9,3 +9,11 @@ output "current_kubernetes_version" {
 output "fqdn" {
   value = azurerm_kubernetes_cluster.main.fqdn
 }
+
+output "identity" {
+  value = azurerm_kubernetes_cluster.main.identity
+}
+
+output "kubelet_identity" {
+  value = azurerm_kubernetes_cluster.main.kubelet_identity
+}

--- a/src/modules/role_assignments/built_in_role/main.tf
+++ b/src/modules/role_assignments/built_in_role/main.tf
@@ -28,6 +28,27 @@ resource "azurerm_role_assignment" "main" {
     : each.value.principal_type == "group_name"
     ? data.azuread_group.groups[each.value.principal].object_id
 
+    : each.value.principal_type == "aks_kubelet_identities"
+    ? var.resources[
+      can(regex("/", each.value.principal))
+      ? split("/", each.value.principal)[0]
+      : try(var.settings.lz_key, var.client_config.landingzone_key)
+      ].kubernetes_clusters[
+      can(regex("/", each.value.principal))
+      ? split("/", each.value.principal)[1]
+      : each.value.principal
+    ].kubelet_identity[0].object_id
+
+    : each.value.principal_type == "aks_cluster_identities"
+    ? var.resources[
+      can(regex("/", each.value.principal))
+      ? split("/", each.value.principal)[0]
+      : try(var.settings.lz_key, var.client_config.landingzone_key)
+      ].kubernetes_clusters[
+      can(regex("/", each.value.principal))
+      ? split("/", each.value.principal)[1]
+      : each.value.principal
+    ].identity[0].principal_id
 
     : var.resources[
       can(regex("/", each.value.principal))


### PR DESCRIPTION
Adds AKS principal support and federated identity credential support on top of the current main branch.

- Exposes AKS cluster identity outputs from the Kubernetes modules.
- Allows AKS identities to be used as principals in role assignments.
- Adds support for multiple federated identity credentials in Azure AD applications.
- Updates the Azure AD application example tfvars with federated identity credential configuration.