### PR TITLE
Pass through gateway preservation settings

### DIFF
--- a/src/modules/_networking/application_gateway/main.tf
+++ b/src/modules/_networking/application_gateway/main.tf
@@ -17,6 +17,14 @@ resource "azurerm_application_gateway" "main" {
     true
   )
 
+  dynamic "global" {
+    for_each = can(var.settings.global) ? [1] : []
+    content {
+      request_buffering_enabled  = try(var.settings.global.request_buffering_enabled, null)
+      response_buffering_enabled = try(var.settings.global.response_buffering_enabled, null)
+    }
+  }
+
   dynamic "identity" {
     for_each = can(var.settings.identity) ? [1] : []
     content {

--- a/src/modules/_networking/virtual_network_gateway_connections/main.tf
+++ b/src/modules/_networking/virtual_network_gateway_connections/main.tf
@@ -17,6 +17,14 @@ resource "azurerm_virtual_network_gateway_connection" "main" {
   express_route_gateway_bypass       = try(var.settings.express_route_gateway_bypass, false)
   local_azure_ip_address_enabled     = try(var.settings.local_azure_ip_address_enabled, false)
 
+  dynamic "custom_bgp_addresses" {
+    for_each = can(var.settings.custom_bgp_addresses) ? [1] : []
+    content {
+      primary   = try(var.settings.custom_bgp_addresses.primary, null)
+      secondary = try(var.settings.custom_bgp_addresses.secondary, null)
+    }
+  }
+
   shared_key = try(var.settings.shared_key, null) != null ? var.settings.shared_key : (
     try(var.settings.shared_key_secret, null) != null && length(data.azurerm_key_vault_secret.main) > 0
     ? data.azurerm_key_vault_secret.main[0].value


### PR DESCRIPTION
## Summary

Preserves existing Azure Application Gateway global buffering settings and VPN connection custom BGP addresses by passing those tfvars settings through to the underlying AzureRM resources.

## Changes

- Adds support for `global` on `azurerm_application_gateway`.
- Passes through `request_buffering_enabled` and `response_buffering_enabled`.
- Adds support for `custom_bgp_addresses` on `azurerm_virtual_network_gateway_connection`.
- Passes through `primary` and `secondary` custom BGP addresses.